### PR TITLE
Force using APIv2.0 calls

### DIFF
--- a/lib/bitbucket_rest_api/invitations.rb
+++ b/lib/bitbucket_rest_api/invitations.rb
@@ -8,7 +8,9 @@ module BitBucket
       _validate_presence_of emailaddress
       perm ||= "write"
 
-      post_request("/2.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
+      # Force using 1.0, because it is still available:
+      # https://support.atlassian.com/bitbucket-cloud/docs/use-bitbucket-rest-api-version-1/
+      post_request("/1.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
                    permission: perm)
     end
   end

--- a/lib/bitbucket_rest_api/invitations.rb
+++ b/lib/bitbucket_rest_api/invitations.rb
@@ -8,7 +8,7 @@ module BitBucket
       _validate_presence_of emailaddress
       perm ||= "write"
 
-      post_request("/1.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
+      post_request("/2.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
                    permission: perm)
     end
   end

--- a/lib/bitbucket_rest_api/issues.rb
+++ b/lib/bitbucket_rest_api/issues.rb
@@ -82,7 +82,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       assert_valid_values(VALID_ISSUE_PARAM_VALUES, params)
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues", params)
       return response.issues unless block_given?
       response.issues.each { |el| yield el }
     end
@@ -103,7 +103,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue, params)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}", params)
     end
 
     alias :find :get
@@ -122,7 +122,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue, params)
 
-      delete_request("/1.0/repositories/#{user}/#{repo}/issues/#{issue_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo}/issues/#{issue_id}", params)
     end
 
     # Create an issue
@@ -173,7 +173,7 @@ module BitBucket
       filter! VALID_ISSUE_PARAM_NAMES, params
       assert_required_keys(%w[ title ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/", params)
     end
 
     # Edit an issue
@@ -223,7 +223,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       filter! VALID_ISSUE_PARAM_NAMES, params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/", params)
     end
 
   end # Issues

--- a/lib/bitbucket_rest_api/issues/comments.rb
+++ b/lib/bitbucket_rest_api/issues/comments.rb
@@ -27,7 +27,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -47,7 +47,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
     alias :find :get
 
@@ -71,7 +71,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
     end
 
     # Edit a comment
@@ -94,7 +94,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
 
     # Delete a comment
@@ -111,7 +111,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
 
   end # Issues::Comments

--- a/lib/bitbucket_rest_api/issues/components.rb
+++ b/lib/bitbucket_rest_api/issues/components.rb
@@ -21,7 +21,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -39,7 +39,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :find :get
 
@@ -60,7 +60,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
     end
 
     # Update a component
@@ -82,7 +82,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :edit :update
 
@@ -99,7 +99,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
 
   end # Issues::Components

--- a/lib/bitbucket_rest_api/issues/milestones.rb
+++ b/lib/bitbucket_rest_api/issues/milestones.rb
@@ -24,7 +24,7 @@ module BitBucket
 
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -42,7 +42,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
     alias :find :get
 
@@ -63,7 +63,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
     end
 
     # Update a milestone
@@ -85,7 +85,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
     # Delete a milestone
@@ -100,7 +100,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
   end # Issues::Milestones

--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -116,7 +116,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless (user? && repo?)
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/branches/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/branches/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -158,7 +158,7 @@ module BitBucket
       assert_required_keys(%w[ name ], params)
 
       # Requires authenticated user
-      post_request("/1.0/repositories/", DEFAULT_REPO_OPTIONS.merge(params))
+      post_request("/2.0/repositories/", DEFAULT_REPO_OPTIONS.merge(params))
     end
 
     # Edit a repository
@@ -188,7 +188,7 @@ module BitBucket
       normalize! params
       filter! VALID_REPO_OPTIONS, params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/", DEFAULT_REPO_OPTIONS.merge(params))
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/", DEFAULT_REPO_OPTIONS.merge(params))
     end
 
     # Get a repository
@@ -202,7 +202,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}", params)
     end
 
     alias :find :get
@@ -218,7 +218,7 @@ module BitBucket
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}")
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}")
     end
 
     # List repositories for the authenticated user
@@ -239,7 +239,7 @@ module BitBucket
       normalize! params
       _merge_user_into_params!(params) unless params.has_key?('user')
       params.merge!('pagelen' => 100) unless params.has_key?('pagelen')
-      
+
       filter! %w[ user role pagelen ], params
 
       response = get_request("/2.0/repositories", params)
@@ -263,7 +263,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/tags/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/tags/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/changesets.rb
+++ b/lib/bitbucket_rest_api/repos/changesets.rb
@@ -28,7 +28,7 @@ module BitBucket
       normalize! params
       filter! %w[ limit start], params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/changesets", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/changesets", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -46,7 +46,7 @@ module BitBucket
       _validate_presence_of sha
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/changesets/#{sha}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/changesets/#{sha}", params)
     end
     alias :find :get
 

--- a/lib/bitbucket_rest_api/repos/following.rb
+++ b/lib/bitbucket_rest_api/repos/following.rb
@@ -15,7 +15,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/followers/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/followers/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -30,7 +30,7 @@ module BitBucket
       params = args.extract_options!
       normalize! params
 
-      response = get_request("/1.0/user/follows", params)
+      response = get_request("/2.0/user/follows", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/forks.rb
+++ b/lib/bitbucket_rest_api/repos/forks.rb
@@ -61,7 +61,7 @@ module BitBucket
       assert_required_keys(REQUIRED_KEY_PARAM_NAMES, params)
       filter! VALID_REPO_OPTIONS, params
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/fork", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/fork", params)
     end
 
 

--- a/lib/bitbucket_rest_api/repos/keys.rb
+++ b/lib/bitbucket_rest_api/repos/keys.rb
@@ -17,7 +17,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -43,7 +43,7 @@ module BitBucket
       assert_required_keys(VALID_KEY_PARAM_NAMES, params)
 
       options = { headers: { "Content-Type" => "application/json" } }
-      post_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/", params, options)
+      post_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/", params, options)
     end
 
     # Edit a key
@@ -66,7 +66,7 @@ module BitBucket
       normalize! params
       filter! VALID_KEY_PARAM_NAMES, params
 
-      put_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
     end
 
     # Delete key
@@ -81,7 +81,7 @@ module BitBucket
       _validate_presence_of key_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
     end
 
   end # Repos::Keys

--- a/lib/bitbucket_rest_api/repos/pull_request.rb
+++ b/lib/bitbucket_rest_api/repos/pull_request.rb
@@ -33,7 +33,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/pullrequests/#{pull_request_id}/participants", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/pullrequests/#{pull_request_id}/participants", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/services.rb
+++ b/lib/bitbucket_rest_api/repos/services.rb
@@ -17,7 +17,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/services", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/services", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -35,7 +35,7 @@ module BitBucket
       _validate_presence_of(service_id)
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
     alias :find :get
 
@@ -58,7 +58,7 @@ module BitBucket
       normalize! params
       assert_required_keys(REQUIRED_KEY_PARAM_NAMES, params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/services", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/services", params)
     end
 
     # Edit a service
@@ -81,7 +81,7 @@ module BitBucket
 
       normalize! params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
 
     # Delete service
@@ -96,7 +96,7 @@ module BitBucket
       _validate_presence_of(service_id)
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
 
   end # Repos::Keys

--- a/lib/bitbucket_rest_api/repos/sources.rb
+++ b/lib/bitbucket_rest_api/repos/sources.rb
@@ -14,7 +14,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       _validate_presence_of(sha, path)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}")
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}")
     end
     alias :all :list
 
@@ -31,7 +31,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       _validate_presence_of(sha, path)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/raw/#{sha}/#{path}")
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/raw/#{sha}/#{path}")
     end
     alias :find :get
 

--- a/lib/bitbucket_rest_api/user.rb
+++ b/lib/bitbucket_rest_api/user.rb
@@ -26,7 +26,7 @@ module BitBucket
     #  bitbucket.user_api.profile
     #
     def profile
-      get_request("/1.0/user")
+      get_request("/2.0/user")
     end
 
 
@@ -48,14 +48,14 @@ module BitBucket
       normalize! params
       filter! DEFAULT_USER_OPTIONS, params
 
-      put_request("/1.0/user", DEFAULT_USER_OPTIONS.merge(params))
+      put_request("/2.0/user", DEFAULT_USER_OPTIONS.merge(params))
 
     end
 
 
     # GET a list of user privileges
     def privileges
-      get_request("/1.0/user/privileges")
+      get_request("/2.0/user/privileges")
     end
 
 
@@ -66,7 +66,7 @@ module BitBucket
     # if the repository is a fork of another repository.
     # An account always "follows" its own repositories.
     def follows
-      get_request("/1.0/user/follows")
+      get_request("/2.0/user/follows")
     end
 
 
@@ -75,7 +75,7 @@ module BitBucket
     # or has at least read access to.
     # Use this if you're looking for a full list of all of the repositories associated with a user.
     def repositories
-      get_request("/1.0/user/repositories")
+      get_request("/2.0/user/repositories")
     end
 
     alias :repos :repositories
@@ -86,7 +86,7 @@ module BitBucket
     # Gets a list of the repositories the account follows.
     # This is the same list that appears on the Following tab on your account dashboard.
     def overview
-      get_request("/1.0/user/repositories/overview")
+      get_request("/2.0/user/repositories/overview")
     end
 
 
@@ -94,7 +94,7 @@ module BitBucket
     # GET the list of repositories on the dashboard
     # Gets the repositories list from the account's dashboard.
     def dashboard
-      get_request("/1.0/user/repositories/dashboard")
+      get_request("/2.0/user/repositories/dashboard")
     end
 
   end # User

--- a/lib/bitbucket_rest_api/users/account.rb
+++ b/lib/bitbucket_rest_api/users/account.rb
@@ -3,51 +3,51 @@
 module BitBucket
   class Users::Account < API
 
-    # API about users/account , please refer to 
+    # API about users/account , please refer to
     # https://confluence.atlassian.com/display/BITBUCKET/account+Resource
-    #  
+    #
 
 
     # GET the account profile
-    # 
+    #
     def profile(accountname)
-      response = get_request("/1.0/users/#{accountname}")
+      response = get_request("/2.0/users/#{accountname}")
     end
 
     # GET the account plan
     def plan(accountname)
-      response = get_request("/1.0/users/#{accountname}/plan")
+      response = get_request("/2.0/users/#{accountname}/plan")
     end
 
     # GET the emails
     def emails(accountname)
-      response = get_request("/1.0/users/#{accountname}/emails")
+      response = get_request("/2.0/users/#{accountname}/emails")
     end
 
     # GET the followers
     def followers(accountname)
-      response = get_request("/1.0/users/#{accountname}/followers")
+      response = get_request("/2.0/users/#{accountname}/followers")
     end
 
     # GET the events
     def events(accountname)
-      response = get_request("/1.0/users/#{accountname}/events")
+      response = get_request("/2.0/users/#{accountname}/events")
     end
 
     #GET the keys
     def keys(accountname)
-      response = get_request("/1.0/users/#{accountname}/ssh-keys")
+      response = get_request("/2.0/users/#{accountname}/ssh-keys")
     end
 
     #POST a new key
     # params should be in format {key: "", label:""}
     def new_key(accountname, params)
-      response = post_request("/1.0/users/#{accountname}/ssh-keys/", params)
+      response = post_request("/2.0/users/#{accountname}/ssh-keys/", params)
     end
 
     #DELETE a key
     def delete_key(accountname, key_id)
-      response = delete_request("/1.0/users/#{accountname}/ssh-keys/#{key_id}")
+      response = delete_request("/2.0/users/#{accountname}/ssh-keys/#{key_id}")
     end
   end # Users::Account
 end # BitBucket

--- a/spec/bitbucket_rest_api/invitations_spec.rb
+++ b/spec/bitbucket_rest_api/invitations_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Invitations do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        "/1.0/invitations/mock_username/mock_repo/mock_email_address",
+        "/2.0/invitations/mock_username/mock_repo/mock_email_address",
         { :permission => 'read' },
         {}
       )
@@ -18,4 +18,3 @@ describe BitBucket::Invitations do
     end
   end
 end
-

--- a/spec/bitbucket_rest_api/issues/comments_spec.rb
+++ b/spec/bitbucket_rest_api/issues/comments_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
+        '/2.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
         {},
         {}
       ).and_return(['comment1', 'comment2', 'comment3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
+        '/2.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
         {'content' => 'mock_comment'},
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {'content' => 'new_mock_comment'},
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {},
         {}
       )
@@ -86,4 +86,3 @@ describe BitBucket::Issues::Comments do
     end
   end
 end
-

--- a/spec/bitbucket_rest_api/issues/components_spec.rb
+++ b/spec/bitbucket_rest_api/issues/components_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/components',
+        '/2.0/repositories/mock_username/mock_repo/issues/components',
         {},
         {}
       ).and_return(['component1', 'component2', 'component3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/components',
+        '/2.0/repositories/mock_username/mock_repo/issues/components',
         { 'name' => 'mock_name' },
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         { 'name' => 'mock_name' },
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/issues/milestones_spec.rb
+++ b/spec/bitbucket_rest_api/issues/milestones_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones',
         {},
         {}
       ).and_return(['milsetone1', 'milestone2', 'milestone3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones',
         { 'name' => 'mock_name' },
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         { 'name' => 'mock_name' },
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/issues_spec.rb
+++ b/spec/bitbucket_rest_api/issues_spec.rb
@@ -8,7 +8,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/',
+        '/2.0/repositories/mock_username/mock_repo/issues/',
         { 'title' => 'mock_issue' },
         {}
       )
@@ -23,7 +23,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/1/',
+        '/2.0/repositories/mock_username/mock_repo/issues/1/',
         { 'title' => 'new_title' },
         {}
       )
@@ -38,7 +38,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/1',
+        '/2.0/repositories/mock_username/mock_repo/issues/1',
         {},
         {}
       )
@@ -53,7 +53,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/1',
+        '/2.0/repositories/mock_username/mock_repo/issues/1',
         {},
         {}
       )
@@ -68,7 +68,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues',
+        '/2.0/repositories/mock_username/mock_repo/issues',
         {},
         {}
       ).and_return(OpenStruct.new(:issues => [])).twice

--- a/spec/bitbucket_rest_api/repos/changesets_spec.rb
+++ b/spec/bitbucket_rest_api/repos/changesets_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Repos::Changesets do
     before do
       expect(changesets).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/changesets',
+        '/2.0/repositories/mock_username/mock_repo/changesets',
         {},
         {}
       ).and_return(['changset1', 'changeset2', 'changeset3'])
@@ -30,7 +30,7 @@ describe BitBucket::Repos::Changesets do
     before do
       expect(changesets).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/changesets/test_sha',
+        '/2.0/repositories/mock_username/mock_repo/changesets/test_sha',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/repos/following_spec.rb
+++ b/spec/bitbucket_rest_api/repos/following_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Repos::Following do
     before do
       expect(following).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/followers/',
+        '/2.0/repositories/mock_username/mock_repo/followers/',
         {},
         {}
       ).and_return(['follower1', 'follower2', 'follower3'])
@@ -31,7 +31,7 @@ describe BitBucket::Repos::Following do
     before do
       expect(following).to receive(:request).with(
         :get,
-        '/1.0/user/follows',
+        '/2.0/user/follows',
         {},
         {}
       ).and_return(['followed1', 'followed2', 'followed3'])

--- a/spec/bitbucket_rest_api/repos/forks_spec.rb
+++ b/spec/bitbucket_rest_api/repos/forks_spec.rb
@@ -32,7 +32,7 @@ describe BitBucket::Repos::Forks do
     before do
       expect(forks).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/fork',
+        '/2.0/repositories/mock_username/mock_repo/fork',
         { 'name' => 'mock_fork_name'},
         {}
       )

--- a/spec/bitbucket_rest_api/repos/keys_spec.rb
+++ b/spec/bitbucket_rest_api/repos/keys_spec.rb
@@ -6,7 +6,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/',
         {},
         {}
       ).and_return(['key1', 'key2', 'key3'])
@@ -29,7 +29,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/',
         { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
         { headers: {"Content-Type"=>"application/json"} }
       )
@@ -44,7 +44,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
          :put,
-         '/1.0/repositories/mock_username/mock_repo/deploy-keys/1',
+         '/2.0/repositories/mock_username/mock_repo/deploy-keys/1',
          { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
          {}
        )
@@ -59,7 +59,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/mock_id',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/mock_id',
         { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
         {}
       )

--- a/spec/bitbucket_rest_api/repos/pull_request_spec.rb
+++ b/spec/bitbucket_rest_api/repos/pull_request_spec.rb
@@ -29,7 +29,7 @@ describe BitBucket::Repos::PullRequest do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        "/1.0/repositories/mock_user/mock_repo/pullrequests/mock_pull_request_id/participants",
+        "/2.0/repositories/mock_user/mock_repo/pullrequests/mock_pull_request_id/participants",
         {},
         {}
       ).and_return(['participant1', 'participant2', 'participant3'])

--- a/spec/bitbucket_rest_api/repos/sources_spec.rb
+++ b/spec/bitbucket_rest_api/repos/sources_spec.rb
@@ -19,7 +19,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/',
+          '/2.0/repositories/mock_username/mock_repo/src/moch_sha/',
           {},
           {}
         )
@@ -34,7 +34,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/app/controller',
+          '/2.0/repositories/mock_username/mock_repo/src/moch_sha/app/controller',
           {},
           {}
         )
@@ -63,7 +63,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/raw/moch_sha/app/assets/images/logo.jpg',
+          '/2.0/repositories/mock_username/mock_repo/raw/moch_sha/app/assets/images/logo.jpg',
           {},
           {}
         )

--- a/spec/bitbucket_rest_api/repos_spec.rb
+++ b/spec/bitbucket_rest_api/repos_spec.rb
@@ -15,7 +15,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :post,
-        '/1.0/repositories/',
+        '/2.0/repositories/',
         BitBucket::Repos::DEFAULT_REPO_OPTIONS.merge({ 'owner' => 'mock_owner', 'name' => 'mock_repo' }),
         {}
       )
@@ -30,7 +30,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo',
+        '/2.0/repositories/mock_username/mock_repo',
         {},
         {}
       )
@@ -46,7 +46,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/branches/',
+        '/2.0/repositories/mock_username/mock_repo/branches/',
         {},
         {}
       ).and_return(['branch1', 'branch2', 'branch3'])
@@ -69,7 +69,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/',
+        '/2.0/repositories/mock_username/mock_repo/',
         BitBucket::Repos::DEFAULT_REPO_OPTIONS.merge({ 'owner' => 'mock_owner' }),
         {}
       )
@@ -85,7 +85,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo',
+        '/2.0/repositories/mock_username/mock_repo',
         {},
         {}
       )
@@ -124,7 +124,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/tags/',
+        '/2.0/repositories/mock_username/mock_repo/tags/',
         {},
         {}
       ).and_return(['tag1', 'tag2' ,'tag3'])

--- a/spec/bitbucket_rest_api/request_spec.rb
+++ b/spec/bitbucket_rest_api/request_spec.rb
@@ -17,19 +17,19 @@ describe BitBucket::Request do
       end
 
       it "supports get" do
-        stub_request(:get, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:get, "https://api.bitbucket.org/2.0/endpoint").
          with(:headers => {
           'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Accept-Encoding' => 'gzip;q=2.0,deflate;q=0.6,identity;q=0.3',
           'Authorization' => 'Bearer 12345',
           'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:get, '/1.0/endpoint', {}, {})
+        fake_api.new.request(:get, '/2.0/endpoint', {}, {})
       end
 
       it "supports put" do
-        stub_request(:put, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:put, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -38,11 +38,11 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:put, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:put, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
 
       it "supports patch" do
-        stub_request(:patch, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:patch, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -51,21 +51,21 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:patch, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:patch, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
 
       it "supports delete" do
-        stub_request(:delete, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:delete, "https://api.bitbucket.org/2.0/endpoint").
          with(:headers => {
           'Accept' => '*/*',
           'Authorization' => 'Bearer 12345',
           'User-Agent' => 'Faraday v0.9.2'
           })
-        fake_api.new.request(:delete, '/1.0/endpoint', {}, {})
+        fake_api.new.request(:delete, '/2.0/endpoint', {}, {})
       end
 
       it "supports post" do
-        stub_request(:post, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:post, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -74,7 +74,7 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:post, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:post, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
     end
   end

--- a/spec/bitbucket_rest_api/user_spec.rb
+++ b/spec/bitbucket_rest_api/user_spec.rb
@@ -17,7 +17,7 @@ describe BitBucket::User do
 
   describe '#profile' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user', {}, {})
       @user.profile
     end
   end
@@ -28,49 +28,49 @@ describe BitBucket::User do
     end
 
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:put, '/1.0/user', params, {})
+      expect(@user).to receive(:request).with(:put, '/2.0/user', params, {})
       @user.update(params)
     end
   end
 
   describe '#privileges' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/privileges', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/privileges', {}, {})
       @user.privileges
     end
   end
 
   describe '#follows' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/follows', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/follows', {}, {})
       @user.follows
     end
   end
 
   describe '#repositories' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories', {}, {})
       @user.repositories
     end
   end
 
   describe '#repos' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories', {}, {})
       @user.repos
     end
   end
 
   describe '#overview' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories/overview', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories/overview', {}, {})
       @user.overview
     end
   end
 
   describe '#dashboard' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories/dashboard', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories/dashboard', {}, {})
       @user.dashboard
     end
   end


### PR DESCRIPTION
Bitbucket Cloud API 1.0 was not supported anymore: https://support.atlassian.com/bitbucket-cloud/docs/use-bitbucket-rest-api-version-1/

PRs & their comments were successfully exported with that simple changes